### PR TITLE
Zabbix 7.2 compatible and CSV exports

### DIFF
--- a/views/sql.form.view.php
+++ b/views/sql.form.view.php
@@ -9,6 +9,9 @@ use Modules\SqlExplorer\Helpers\Html\ScriptTag;
 $url = (new Curl())
     ->setArgument('action', 'sqlexplorer.form')
     ->getUrl();
+
+define('ZBX_DB_ORACLE', 3); // Dummy value. Oracle DB support was dropped. With this change it works on Zabbix 7.2.3
+
 $db_label = [
     ZBX_DB_MYSQL => _('MySQL'),
     ZBX_DB_POSTGRESQL => _('Postgre'),

--- a/views/sql.form.view.php
+++ b/views/sql.form.view.php
@@ -10,7 +10,9 @@ $url = (new Curl())
     ->setArgument('action', 'sqlexplorer.form')
     ->getUrl();
 
-define('ZBX_DB_ORACLE', 3); // Dummy value. Oracle DB support was dropped. With this change it works on Zabbix 7.2.3
+if (version_compare(ZABBIX_VERSION, '7.2.0', '>')) { 
+    define('ZBX_DB_ORACLE', 3);  // Sets dummy value since Oracle DB support was dropped on 7.2. Makes it compatible with 7.2+ onwards
+} 
 
 $db_label = [
     ZBX_DB_MYSQL => _('MySQL'),


### PR DESCRIPTION
Hello, I saw your module and thought it was awesome! 
Needed to make a few changes to make it work with a more modern Zabbix 7.2 instance, where they dropped oracle db support.

Also had a few issues while exporting csvs when the query returned stuff with multiple lines on it.
Hope you find it useful! Any issue please ask